### PR TITLE
Use types-setuptools in precommit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
         additional_dependencies:
           [
             types-click,
-            types-pkg_resources,
+            types-setuptools,
             types-requests,
             types-tabulate,
             types-Deprecated,


### PR DESCRIPTION
types-pkg-resources has been yanked.
They suggest to use types-setuptools instead.